### PR TITLE
removed empty q5_2 test file

### DIFF
--- a/materials/x19/hw/2/hw06/tests/q5_2.py
+++ b/materials/x19/hw/2/hw06/tests/q5_2.py
@@ -1,7 +1,0 @@
-test = {
-  'name': 'Question 5_2',
-  'points': 1,
-  'suites': [
-  
-  ]
-}


### PR DESCRIPTION
Did this to stop the final run-all-tests autograder code in hw06 from outputting an assertion error.